### PR TITLE
[#72] implement backend api to retrieve a students degree plan

### DIFF
--- a/backend/src/models/CourseModel.js
+++ b/backend/src/models/CourseModel.js
@@ -1,5 +1,5 @@
 /**
- * File: backend/src/models/CoursesModel.js
+ * File: backend/src/models/CourseModel.js
  * Model for interacting with the courses entity in the database
  */
 
@@ -25,3 +25,7 @@ async function getPrerequisitesForCourse(courseId) {
         throw error;
     }
 }
+
+module.exports = {
+    getPrerequisitesForCourse,
+};

--- a/backend/src/models/CoursesModel.js
+++ b/backend/src/models/CoursesModel.js
@@ -1,0 +1,27 @@
+/**
+ * File: backend/src/models/CoursesModel.js
+ * Model for interacting with the courses entity in the database
+ */
+
+const pool = require('../db');
+
+/**
+ * Get prerequisites for a given course by its internal ID.
+ * @param courseId - the internal ID of the course
+ * @returns A promise that resolves to an array of prerequisite course objects for the given course ID.
+ */
+async function getPrerequisitesForCourse(courseId) {
+    try {
+        const result = await pool.query(
+            `SELECT prereq.course_id, prereq.course_code, prereq.course_name, prereq.credits
+            FROM course_prerequisites cp
+            JOIN courses prereq ON cp.prerequisite_course_id = prereq.course_id
+            WHERE cp.course_id = $1`,
+            [courseId]
+        );
+        return result.rows;
+    } catch (error) {
+        console.error('Error fetching prerequisites:', error);
+        throw error;
+    }
+}

--- a/backend/src/models/DegreePlanModel.js
+++ b/backend/src/models/DegreePlanModel.js
@@ -13,7 +13,18 @@ const pool = require('../db');
 async function getDegreePlanByStudentId(studentId) {
     try {
         const result = await pool.query(
-            `SELECT * FROM degree_plans WHERE student_id = $1`,
+            `SELECT dp.plan_id, dp.course_status,
+                    c.course_id, c.course_code, c.course_name, c.credits,
+                    s.semester_id, s.semester_name, s.semester_type,
+                    s.sem_start_date, s.sem_end_date,
+                    p.program_id, p.program_name, p.program_type
+            FROM degree_plans dp
+            JOIN courses c ON dp.course_id = c.course_id
+            JOIN semesters s on dp.semester_id = s.semester_id
+            JOIN students st ON dp.student_id = st.student_id
+            JOIN programs p ON st.program_id = p.program_id
+            WHERE dp.student_id = $1
+            ORDER BY s.sem_start_date ASC`,
             [studentId]
         );
         // return all degree plan entries (courses in the plan) for the student

--- a/backend/src/models/DegreePlanModel.js
+++ b/backend/src/models/DegreePlanModel.js
@@ -1,0 +1,30 @@
+/**
+ * File: backend/src/models/DegreePlanModel.js
+ * Model for interacting with the degree_plans table in the database.
+ */
+
+const pool = require('../db');
+
+/**
+ * Get the degree plan for a specific student.
+ * @param studentId - The internal ID of the student (not school ID).
+ * @returns A promise that resolves to an array of degree plan entries for the student (courses in the plan).
+ */
+async function getDegreePlanByStudentId(studentId) {
+    try {
+        const result = await pool.query(
+            `SELECT * FROM degree_plans WHERE student_id = $1`,
+            [studentId]
+        );
+        // return all degree plan entries (courses in the plan) for the student
+        return result.rows;
+    } catch (error) {
+        console.error('Error fetching degree plan:', error);
+        throw error;
+    }
+}
+
+module.exports = {
+    getDegreePlanByStudentId,
+}
+

--- a/backend/src/models/DegreePlanModel.js
+++ b/backend/src/models/DegreePlanModel.js
@@ -13,7 +13,7 @@ const pool = require('../db');
 async function getDegreePlanByStudentId(studentId) {
     try {
         const result = await pool.query(
-            `SELECT dp.plan_id, dp.course_status,
+            `SELECT dp.student_id, dp.plan_id, dp.course_status,
                     c.course_id, c.course_code, c.course_name, c.credits,
                     s.semester_id, s.semester_name, s.semester_type,
                     s.sem_start_date, s.sem_end_date,

--- a/backend/src/models/DegreePlanModel.js
+++ b/backend/src/models/DegreePlanModel.js
@@ -6,7 +6,7 @@
 const pool = require('../db');
 
 /**
- * Get the degree plan for a specific student.
+ * Get the degree plan for a specific student by their internal student ID.
  * @param studentId - The internal ID of the student (not school ID).
  * @returns A promise that resolves to an array of degree plan entries for the student (courses in the plan).
  */

--- a/backend/src/models/DegreePlanModel.js
+++ b/backend/src/models/DegreePlanModel.js
@@ -16,15 +16,12 @@ async function getDegreePlanByStudentId(studentId) {
             `SELECT dp.student_id, dp.plan_id, dp.course_status,
                     c.course_id, c.course_code, c.course_name, c.credits,
                     s.semester_id, s.semester_name, s.semester_type,
-                    s.sem_start_date, s.sem_end_date,
-                    p.program_id, p.program_name, p.program_type
+                    s.sem_start_date, s.sem_end_date
             FROM degree_plans dp
             JOIN courses c ON dp.course_id = c.course_id
             JOIN semesters s on dp.semester_id = s.semester_id
-            JOIN students st ON dp.student_id = st.student_id
-            JOIN programs p ON st.program_id = p.program_id
             WHERE dp.student_id = $1
-            ORDER BY s.sem_start_date ASC`,
+            ORDER BY s.sem_start_date ASC, c.course_code ASC`,
             [studentId]
         );
         // return all degree plan entries (courses in the plan) for the student

--- a/backend/src/models/StudentModel.js
+++ b/backend/src/models/StudentModel.js
@@ -14,7 +14,17 @@ const pool = require('../db');
 async function getStudentBySchoolId(schoolStudentId) {
     try {
         const result = await pool.query(
-            'SELECT * FROM students WHERE school_student_id = $1',
+            `SELECT s.student_id,
+                    s.school_student_id,
+                    u.first_name,
+                    u.last_name,
+                    u.email,
+                    u.phone_number,
+                    p.program_name
+            FROM students s
+            JOIN users u ON s.user_id = u.user_id
+            LEFT JOIN programs p ON s.program_id = p.program_id
+            WHERE s.school_student_id = $1`,
             [schoolStudentId]
         );
         return result.rows[0]; // returns the student object or undefined if not found

--- a/backend/src/routes/students.js
+++ b/backend/src/routes/students.js
@@ -8,7 +8,7 @@ const router = express.Router();
 const StudentModel = require('../models/StudentModel');
 const AccessModel = require('../models/AccessModel');
 const DegreePlanModel = require('../models/DegreePlanModel');
-const CoursesModel = require('../models/CoursesModel');
+const CourseModel = require('../models/CourseModel');
 
 /**
  * Route: GET /students/:schoolId
@@ -90,7 +90,7 @@ router.get('/:schoolId/degree-plan', async (req, res) => {
             // add prerequisites to each course in the degree plan
             degreePlan = await Promise.all(
                 degreePlan.map(async (course) => {
-                    const prerequisites = await CoursesModel.getPrerequisitesForCourse(course.course_id);
+                    const prerequisites = await CourseModel.getPrerequisitesForCourse(course.course_id);
                     return {
                         ...course,
                         prerequisites

--- a/backend/src/routes/students.js
+++ b/backend/src/routes/students.js
@@ -8,6 +8,7 @@ const router = express.Router();
 const StudentModel = require('../models/StudentModel');
 const AccessModel = require('../models/AccessModel');
 const DegreePlanModel = require('../models/DegreePlanModel');
+const CoursesModel = require('../models/CoursesModel');
 
 /**
  * Route: GET /students/:schoolId
@@ -54,7 +55,7 @@ router.get('/:schoolId', async (req, res) => {
 
 /**
  * Route: GET /students/:schoolId/degree-plan
- * Retrieves the degree plan for a student by their school ID.
+ * Retrieves the degree plan and student info for a student by their school ID.
  */
 router.get('/:schoolId/degree-plan', async (req, res) => {
     const { schoolId } = req.params;
@@ -75,28 +76,36 @@ router.get('/:schoolId/degree-plan', async (req, res) => {
 
         // check access permissions
         const userRoles = await AccessModel.getUserRoles(currentUser.user_id);
+        let hasAccess = false;
 
         if (userRoles.includes('admin')) {
-            // admin has access to all students
-            const degreePlan = await DegreePlanModel.getDegreePlanByStudentId(student.student_id);
-            return res.json(degreePlan);
-        }
-        if (userRoles.includes('advisor')) {
-            const hasAccess = await AccessModel.isAdvisorOfStudent(currentUser.user_id, student.student_id);
-            
-            if (hasAccess) {
-                const degreePlan = await DegreePlanModel.getDegreePlanByStudentId(student.student_id);
-                return res.json(degreePlan);
-            } else {
-                return res.status(404).json({ message: 'Student not found' });
-            }
+            hasAccess = true;
+        } else if (userRoles.includes('advisor')) {
+            hasAccess = await AccessModel.isAdvisorOfStudent(currentUser.user_id, student.student_id);
         }
 
+        if (hasAccess) {
+            let degreePlan = await DegreePlanModel.getDegreePlanByStudentId(student.student_id);
+
+            // add prerequisites to each course in the degree plan
+            degreePlan = await Promise.all(
+                degreePlan.map(async (course) => {
+                    const prerequisites = await CoursesModel.getPrerequisitesForCourse(course.course_id);
+                    return {
+                        ...course,
+                        prerequisites
+                    };
+                })
+            );
+            return res.json({ student, degreePlan });
+        } else {
+            return res.status(403).json({ message: 'Forbidden: You do not have access to this student\'s degree plan' });
+        }
     } catch (error) {
         console.error('Error fetching degree plan:', error);
         res.status(500).json({ message: 'Internal server error' });
     }
-})
+});
 
 module.exports = router;
 

--- a/backend/tests/models/CourseModel.test.js
+++ b/backend/tests/models/CourseModel.test.js
@@ -1,6 +1,7 @@
 /**
  * File: backend/tests/models/CourseModel.test.js
  * Unit tests for CourseModel.js using Jest
+ * Tests assume certain values in seed data, if seed data changes, tests may need to be updated
  */
 
 const CourseModel = require('../../src/models/CourseModel');

--- a/backend/tests/models/CourseModel.test.js
+++ b/backend/tests/models/CourseModel.test.js
@@ -1,0 +1,52 @@
+/**
+ * File: backend/tests/models/CourseModel.test.js
+ * Unit tests for CourseModel.js using Jest
+ */
+
+const CourseModel = require('../../src/models/CourseModel');
+const { runSchemaAndSeeds } = require('../../db_setup');
+const pool = require('../../src/db');
+
+// Reset and seed the database before each test
+beforeAll(async () => {
+    await runSchemaAndSeeds();
+});
+
+// Close the database connection after all tests
+afterAll(async () => {
+    await pool.end();
+});
+
+/**
+ * Tests for CourseModel
+ */
+describe('CourseModel', () => {
+
+    // Test for getting prerequisites for a valid course ID
+    // course with course_id 7 should have prerequisites in seed data (update as needed)
+    test('getPrerequisitesForCourse returns prerequisites if exists', async () => {
+        const courseId = 7; // should match your seed data
+        const prerequisites = await CourseModel.getPrerequisitesForCourse(courseId);
+        expect(prerequisites).toBeDefined();
+        expect(Array.isArray(prerequisites)).toBe(true);
+        expect(prerequisites.length).toBeGreaterThan(0);
+    });
+
+    // Test for getting prerequisites for a course with no prerequisites
+    // course with course_id 1 should have no prerequisites in seed data (update as needed)
+    test('getPrerequisitesForCourse returns empty array if no prerequisites', async () => {
+        const courseId = 1; // assuming course_id 1 has no prerequisites in seed data
+        const prerequisites = await CourseModel.getPrerequisitesForCourse(courseId);
+        expect(prerequisites).toBeDefined();
+        expect(Array.isArray(prerequisites)).toBe(true);
+        expect(prerequisites.length).toBe(0);
+    });
+
+    // Test for getting prerequisites for an invalid course ID
+    test('getPrerequisitesForCourse returns empty array for non-existent course', async () => {
+        const prerequisites = await CourseModel.getPrerequisitesForCourse(9999); // assuming 9999 does not exist
+        expect(prerequisites).toBeDefined();
+        expect(Array.isArray(prerequisites)).toBe(true);
+        expect(prerequisites.length).toBe(0);
+    });
+});

--- a/backend/tests/models/DegreePlanModel.test.js
+++ b/backend/tests/models/DegreePlanModel.test.js
@@ -1,6 +1,7 @@
 /**
  * file: backend/tests/models/DegreePlanModel.test.js
  * Unit tests for DegreePlanModel.js using Jest
+ * Tests assume certain values in seed data, if seed data changes, tests may need to be updated
  */
 
 const DegreePlanModel = require('../../src/models/DegreePlanModel');
@@ -34,6 +35,25 @@ describe('DegreePlanModel', () => {
         degreePlan.forEach(plan => {
             expect(plan.student_id).toBe(studentId);
         });
+
+        // check that the first entry has expected fields
+        expect(degreePlan[0]).toHaveProperty('student_id');
+        expect(degreePlan[0]).toHaveProperty('plan_id');
+        expect(degreePlan[0]).toHaveProperty('course_id');
+        expect(degreePlan[0]).toHaveProperty('course_code');
+        expect(degreePlan[0]).toHaveProperty('course_name');
+        expect(degreePlan[0]).toHaveProperty('credits');
+        expect(degreePlan[0]).toHaveProperty('semester_id');
+        expect(degreePlan[0]).toHaveProperty('semester_name');
+        expect(degreePlan[0]).toHaveProperty('semester_type');
+        expect(degreePlan[0]).toHaveProperty('sem_start_date');
+        expect(degreePlan[0]).toHaveProperty('sem_end_date');
+        expect(degreePlan[0]).toHaveProperty('course_status');
+        
+        // check for specific course code in the degree plan (should match seed data)
+        const courseCodes = degreePlan.map(plan => plan.course_code);
+        expect(courseCodes).toContain('OPWL-536'); // should match seed data
+
     });
 
     // Test for getting student degree plan with invalid student ID

--- a/backend/tests/models/DegreePlanModel.test.js
+++ b/backend/tests/models/DegreePlanModel.test.js
@@ -1,0 +1,44 @@
+/**
+ * file: backend/tests/models/DegreePlanModel.test.js
+ * Unit tests for DegreePlanModel.js using Jest
+ */
+
+const DegreePlanModel = require('../../src/models/DegreePlanModel');
+const { runSchemaAndSeeds } = require('../../db_setup');
+const pool = require('../../src/db');
+
+// Reset and seed the database before each test
+beforeAll(async () => {
+    await runSchemaAndSeeds();
+});
+
+// Close the database connection after all tests
+afterAll(async () => {
+    await pool.end();
+});
+
+/**
+ * Tests for DegreePlanModel
+ */
+describe('DegreePlanModel', () => {
+
+    // Test for getting student degree plan with valid school ID
+    // student with student_id 1 should exist in seed data with entries in degree plan table
+    test('getDegreePlanByStudentId returns degree plan if exists', async () => {
+        const studentId = 1;
+        const degreePlan = await DegreePlanModel.getDegreePlanByStudentId(studentId);
+
+        expect(Array.isArray(degreePlan)).toBe(true);
+        expect(degreePlan.length).toBeGreaterThan(0);
+        // check that all the rows belong to the correct student
+        degreePlan.forEach(plan => {
+            expect(plan.student_id).toBe(studentId);
+        });
+    });
+
+    // Test for getting student degree plan with invalid student ID
+    test('getDegreePlanByStudentId returns empty array for non-existent student', async () => {
+        const degreePlan = await DegreePlanModel.getDegreePlanByStudentId(9999); // assuming 9999 does not exist
+        expect(degreePlan).toEqual([]); // should return empty array if no degree plan found
+    });
+});

--- a/backend/tests/models/StudentModel.test.js
+++ b/backend/tests/models/StudentModel.test.js
@@ -1,6 +1,7 @@
 /**
  * File: backend/tests/models/StudentModel.test.js
  * Unit tests for StudentModel.js using Jest
+ * Tests assume certain values in seed data, if seed data changes, tests may need to be updated
  */
 
 const StudentModel = require('../../src/models/StudentModel');
@@ -29,6 +30,8 @@ describe('StudentModel', () => {
         const student = await StudentModel.getStudentBySchoolId(schoolId);
         expect(student).toBeDefined();
         expect(student.school_student_id).toBe(schoolId);
+        expect(student.first_name).toBe('Alice'); // should match seed data
+        expect(student.last_name).toBe('Johnson'); // should match seed data
     });
 
     // Test for getting student with invalid school ID

--- a/backend/tests/routes/students.test.js
+++ b/backend/tests/routes/students.test.js
@@ -2,6 +2,7 @@
  * File: backend/tests/routes/students.test.js
  * Integration tests for student routes using Jest and Supertest
  * Test database should be set up and seeded before running these tests
+ * Tests assume certain values in seed data, if seed data changes, tests may need to be updated
  */
 
 const request = require('supertest');
@@ -95,8 +96,12 @@ describe('GET /students/:schoolId/degree-plan', () => {
         const res = await request(app).get('/students/112299690/degree-plan');
         expect(res.status).toBe(200);
         expect(res.body.student.school_student_id).toBe('112299690');
+        expect(res.body.student.first_name).toBe('Alice'); // should match seed data
+        expect(res.body.student.last_name).toBe('Johnson'); // should match seed data
         expect(Array.isArray(res.body.degreePlan)).toBe(true);
         expect(res.body.degreePlan[0]).toHaveProperty('prerequisites');
+        const courseCodes = res.body.degreePlan.map(course => course.course_code);
+        expect(courseCodes).toContain('OPWL-536'); // should match seed data
     });
 
     // Test for advisor user accessing their assigned student's degree plan
@@ -105,8 +110,12 @@ describe('GET /students/:schoolId/degree-plan', () => {
         const res = await request(app).get('/students/113601927/degree-plan');
         expect(res.status).toBe(200);
         expect(res.body.student.school_student_id).toBe('113601927');
+        expect(res.body.student.first_name).toBe('Bob'); // should match seed data
+        expect(res.body.student.last_name).toBe('Williams'); // should match seed data
         expect(Array.isArray(res.body.degreePlan)).toBe(true);
         expect(res.body.degreePlan[0]).toHaveProperty('prerequisites');
+        const courseCodes = res.body.degreePlan.map(course => course.course_code);
+        expect(courseCodes).toContain('OPWL-536'); // should match seed data
     });
 
     // Test for advisor user accessing a student's degree plan they are not assigned to

--- a/backend/tests/routes/students.test.js
+++ b/backend/tests/routes/students.test.js
@@ -10,6 +10,16 @@ const { runSchemaAndSeeds } = require('../../db_setup');
 const pool = require('../../src/db');
 const studentRoutes = require('../../src/routes/students');
 
+// Reset and seed the database before each test
+    beforeAll(async () => {
+        await runSchemaAndSeeds();
+    });
+
+    // Close the database connection after all tests
+    afterAll(async () => {
+        await pool.end();
+    });
+
 /**
  * Helper function to create an Express app with mocked authentication
  * @param mockUser - The user object to set in req.user
@@ -29,20 +39,11 @@ function makeAppWithUser(mockUser) {
     return app;
 }
 
-// Reset and seed the database before each test
-beforeAll(async () => {
-    await runSchemaAndSeeds();
-});
-
-// Close the database connection after all tests
-afterAll(async () => {
-    await pool.end();
-});
-
 /**
  * Tests for /students/:schoolId route
  */
 describe('GET /students/:schoolId', () => {
+
     // Test for admin user accessing a student user
     // admin user with user ID 1 should exist in seed data
     test('returns student for admin', async () => {
@@ -73,6 +74,60 @@ describe('GET /students/:schoolId', () => {
         const app = makeAppWithUser({ user_id: 1 }); // admin
         const res = await request(app).get('/students/invalid_id');
         expect(res.status).toBe(404);
+    });
+
+    // Test for invalid user (no user info)
+    test('returns 401 for no user info', async () => {  
+        const app = makeAppWithUser(null);
+        const res = await request(app).get('/students/112299690');
+        expect(res.status).toBe(401);
+    });
+});
+
+/**
+ * Tests for /students/:schoolId/degree-plan route
+ */
+describe('GET /students/:schoolId/degree-plan', () => {
+
+    // Test for admin user accessing a student's degree plan
+    test('admin can view any student\'s degree plan', async () => {
+        const app = makeAppWithUser({ user_id: 1 }); // admin
+        const res = await request(app).get('/students/112299690/degree-plan');
+        expect(res.status).toBe(200);
+        expect(res.body.student.school_student_id).toBe('112299690');
+        expect(Array.isArray(res.body.degreePlan)).toBe(true);
+        expect(res.body.degreePlan[0]).toHaveProperty('prerequisites');
+    });
+
+    // Test for advisor user accessing their assigned student's degree plan
+    test('advisor can view assigned student degree plan', async () => {
+        const app = makeAppWithUser({ user_id: 3 }); // advisor with access to student 113601927
+        const res = await request(app).get('/students/113601927/degree-plan');
+        expect(res.status).toBe(200);
+        expect(res.body.student.school_student_id).toBe('113601927');
+        expect(Array.isArray(res.body.degreePlan)).toBe(true);
+        expect(res.body.degreePlan[0]).toHaveProperty('prerequisites');
+    });
+
+    // Test for advisor user accessing a student's degree plan they are not assigned to
+    test('returns 403 for advisor not assigned to student', async () => {
+        const app = makeAppWithUser({ user_id: 3 }); // advisor without access to student 112299690
+        const res = await request(app).get('/students/112299690/degree-plan');
+        expect(res.status).toBe(403);
+    });
+
+    // Test for user looking up a non-existent student's degree plan
+    test('returns 404 for non-existent student', async () => {
+        const app = makeAppWithUser({ user_id: 1 }); // admin
+        const res = await request(app).get('/students/invalid_id/degree-plan');
+        expect(res.status).toBe(404);
+    });
+
+    // Test for invalid user (no user info)
+    test('returns 401 for no user info', async () => {
+        const app = makeAppWithUser(null);
+        const res = await request(app).get('/students/112299690/degree-plan');
+        expect(res.status).toBe(401);
     });
 });
 

--- a/database/seeds.sql
+++ b/database/seeds.sql
@@ -179,3 +179,9 @@ INSERT INTO degree_plans (plan_id, student_id, course_id, semester_id, course_st
 (3, 1, 3, 10, 'Planned'), -- OPWL-560 in Fall 2026
 (4, 1, 9, 8, 'Planned'), -- OPWL-530 in Spring 2026
 (5, 1, 5, 11, 'Planned'); -- OPWL-592 in Spring 2027
+
+-- Insert degree plan entries for Bob Williams (student2)
+INSERT INTO degree_plans (plan_id, student_id, course_id, semester_id, course_status) VALUES
+(6, 2, 1, 7, 'In Progress'), -- OPWL-536 in Fall 2025
+(7, 2, 4, 8, 'Planned'), -- OPWL-518 in Spring 2026
+(8, 2, 5, 9, 'Planned'); -- OPWL-592 in Summer 2026


### PR DESCRIPTION
Closes #72 

- Added route and models to return student and degree plan info to frontend (may need later modifications to return more information (currently not returning certificate info).
- Returns student info (name, email, phone, etc.)
- Returns student degree plan courses (including semester info, prereqs, credit count, etc.)
- Added tests for new code


