### PR TITLE
add theme to github page

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-slate


### PR DESCRIPTION
We can't really see what the theme looks like until this change is merged, since the page is deployed based on changes in main. But here is what the theme I put should look like, let me know if you want a different theme (you can view more themes [here](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/adding-a-theme-to-your-github-pages-site-using-jekyll) )

<img width="1906" height="867" alt="image" src="https://github.com/user-attachments/assets/f55a2466-c224-48ae-94e3-c2da156455e8" />
